### PR TITLE
Basic SSL support

### DIFF
--- a/src/leiningen/ring/run_server.clj
+++ b/src/leiningen/ring/run_server.clj
@@ -13,7 +13,6 @@
 (def suitable-ports (range 3000 3011))
 
 (defn- jetty-server [handler jetty-params]
-  ; (println jetty-params)
   (if (:port jetty-params)
     (run-jetty (wrap-stacktrace handler)
                (assoc jetty-params :join? false))

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -11,17 +11,17 @@
 
 (defn server-task
   "Shared logic for server and server-headless tasks."
-  [{:keys [ring] :as project} port launch-browser]
+  [project port launch-browser]
   (let [
         reload-dirs [(:source-path project)]
         [handler-sym handler-ns] (sym-and-ns project :handler)
         [init-sym init-ns]       (sym-and-ns project :init)
         [destroy-sym destroy-ns] (sym-and-ns project :destroy)
         [report-ports-sym report-ports-ns] (sym-and-ns project :report-ports)
-        jetty-params1 (dissoc ring :handler :init :destroy :report-ports :join)
+        adapter (-> project :ring :adapter)
         jetty-params (if port
-                       (assoc jetty-params1 :port (Integer/parseInt port))
-                       jetty-params1)]
+                       (assoc adapter :port (Integer/parseInt port))
+                       adapter)]
        (eval-in-project project
          `(do
             (leiningen.ring.run-server/run-server


### PR DESCRIPTION
Hi, these two commits allow you to sensibly run jetty with SSL.  The first commit actually adds the functionality (and, indeed, lets through any run-jetty options except :join?).  The second adds a feature to report the ports back to the host application, which is necessary if you're going to create correct URLs that move between the http and https version of the site.

Things it doesn't do:
    \* It doesn't scan for an SSL port.  It just uses the config.
    \* It doesn't allow you to specify an SSL port on the command line.
    \* It doesn't report the host name back to the application 

Ugly things:
    \* The sheer number of functions being passed around suggests a need for a refactor.
    \* The port lookup relies on run-jetty creating the http and then the https connector.

Please let me know what you think.

Thanks,

Julian
