### PR TITLE
Print an explanation when called with an invalid subtask

### DIFF
--- a/src/leiningen/ring.clj
+++ b/src/leiningen/ring.clj
@@ -16,4 +16,7 @@
        "server"          (apply server project args)
        "server-headless" (apply server-headless project args)
        "war"             (apply war project args)
-       "uberwar"         (apply uberwar project args))))
+       "uberwar"         (apply uberwar project args)
+                         (do
+                           (println (str "'" subtask "'") "is not a valid subtask\n")
+                           (ring [project])))))


### PR DESCRIPTION
This woulda saved my bum this morning when I was running "lein ring start".  Hahah

I'm not sure if this should be fixed here or in Leiningen, but I thought I'd raise up the issue.
