### PR TITLE
0.6.0 breaks with a port argument

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -29,4 +29,4 @@
   ([project]
      (server-task project {}))
   ([project port]
-     (server-task project {:port port})))
+     (server-task project {:port (Integer. port)})))

--- a/src/leiningen/ring/server_headless.clj
+++ b/src/leiningen/ring/server_headless.clj
@@ -6,4 +6,4 @@
   ([project]
      (server-task project {:headless? true}))
   ([project port]
-     (server-task project {:port port, :headless? true})))
+     (server-task project {:port (Integer. port), :headless? true})))


### PR DESCRIPTION
Apparently it's gotta be a number now. Didn't dig deep enough to figure out why exactly.
