### PR TITLE
Make war and uberwar compatible with v1.7.x :plugins usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-ring "0.6.1"
+(defproject lein-ring "0.6.2-SNAPSHOT"
   :description "Leiningen Ring plugin"
   :url "https://github.com/weavejester/lein-ring"
   :dependencies [[org.clojure/clojure "1.2.1"]


### PR DESCRIPTION
Needed to use the same cross-compatible `eval-in-project` as now used in the `server` task, as well as a workaround for the implicit `deps` call cleaning `:target-dir`.
