### PR TITLE
Use {:open-browser? false ..} for headless

### DIFF
--- a/src/leiningen/ring/server_headless.clj
+++ b/src/leiningen/ring/server_headless.clj
@@ -4,6 +4,6 @@
 (defn server-headless
   "Start a Ring server without opening a browser."
   ([project]
-     (server-task project {:headless? true}))
+     (server-task project {:open-browser? false}))
   ([project port]
-     (server-task project {:port (Integer. port), :headless? true})))
+     (server-task project {:port (Integer. port), :open-browser? false})))


### PR DESCRIPTION
In 0.6.2 `lein2 ring server-headless` starts the browser.  This patch bumps the version to a new snapshot and uses the new :open-browser? key from lein-server.
