### PR TITLE
Fixed bug where uberwar task no longer excluded servlet-api-*.jar files.

### DIFF
--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -13,11 +13,13 @@
     (->> (:library-path project) io/file .listFiles (map str))))
 
 (defn jar-dependencies [project]
-  (for [file (get-classpath project)
-        :when (and (.endsWith file ".jar")
+  (for [pathname (get-classpath project)
+        :let [file (io/file pathname)
+              fname (.getName file)]
+        :when (and (.endsWith fname ".jar")
                    ;; Servlet container will have it's own servlet-api impl
-                   (not (.startsWith file "servlet-api-")))]
-    (io/file file)))
+                   (not (.startsWith fname "servlet-api-")))]
+    file))
 
 (defn jar-entries [war project]
   (doseq [jar-file (jar-dependencies project)]


### PR DESCRIPTION
Leiningen 2.0 references libraries directly out of your m2 repository instead of your project's lib/ directory. JAR dependency calculations assumed that these libraries pathnames only contained filenames, not
full absolute paths (e.g. "servlet-api.jar" vs. "/home/achin/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api.jar").
