### PR TITLE
Exploded wars

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ The following war-specific options are supported:
 * `:web-xml` -
   web.xml file to use in place of auto-generated version (relative to project root).
 
+* `:war-explode` -
+  If true, war will be created in "exploded" form, i.e. as a directory. Defaults
+  to false.
+
+* `:war-name` -
+  This has the same effect as specifying the filename as an argument to `lein
+  ring war` or `lein ring uberwar`. Note: `lein ring uberwar` also respects
+  the `:uberjar` key in `project.clj`.
+
 These keys should be placed under the `:ring` key in `project.clj`,
 and are optional values. If not supplied, default values will be used instead.
 


### PR DESCRIPTION
Hi James,

I have added a `:war-explode` key to the options for `lein-ring`. If true, the output of `lein ring war` and `lein ring uberwar` will be output to a directory, analogous to `mvn war:exploded`.

I decided to retain the usage of `JarOutputStream` for minimal fuss while assembling the jar. To keep things clean and atomic I shifted the task to first build the jar in a temporary location and then ether copy or unzip it to the final location depending on the value of `:war-explode`.

Please let me know what you think, and thanks for all of your amazing work.

Diego