### PR TITLE
Source path included twice when building a war or uberwar

### DIFF
--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -33,8 +33,8 @@
     (doto war-stream
       (war/str-entry "WEB-INF/web.xml" (war/make-web-xml project))
       (war/dir-entry project "WEB-INF/classes/" (:compile-path project)))
-    (doseq [path (concat [(:source-path project)] (:source-paths project)
-                         [(:resources-path project)] (:resource-paths project))
+    (doseq [path (distinct (concat [(:source-path project)] (:source-paths project)
+                                   [(:resources-path project)] (:resource-paths project)))
             :when path]
       (war/dir-entry war-stream project "WEB-INF/classes/" path))
     (war/dir-entry war-stream project "" (war/war-resources-path project))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -188,8 +188,8 @@
     (doto war-stream
       (str-entry "WEB-INF/web.xml" (make-web-xml project))
       (dir-entry project "WEB-INF/classes/" (:compile-path project)))
-    (doseq [path (concat [(:source-path project)] (:source-paths project)
-                         [(:resources-path project)] (:resource-paths project))
+    (doseq [path (distinct (concat [(:source-path project)] (:source-paths project)
+                                   [(:resources-path project)] (:resource-paths project)))
             :when path]
       (dir-entry war-stream project "WEB-INF/classes/" path))
     (dir-entry war-stream project "" (war-resources-path project))


### PR DESCRIPTION
My source path was being included twice when building a war or uberwar, resulting in the error:

duplicate entry: WEB-INF/classes/courier/config.clj

Lein, when building jars makes sure the paths included are distinct, so I did the same for wars.

I also bumped the version to 0.7.6 (please publish, pretty please).  Thanks!
