### PR TITLE
Fixing: https://github.com/weavejester/lein-ring/issues/46

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -1,5 +1,7 @@
 (ns leiningen.ring.server
-  (:require [leinjacker.deps :as deps])
+  (:require 
+    [leinjacker.deps :as deps]
+    [leiningen.ring.src-paths :refer [src-paths]])
   (:use [leinjacker.eval :only (eval-in-project)]
         [leiningen.ring.util :only (ensure-handler-set! update-project)]))
 
@@ -14,13 +16,14 @@
              s))))
 
 (defn add-server-dep [project]
-  (update-project project deps/add-if-missing '[ring-server "0.2.5"]))
+  (update-project project deps/add-if-missing '[ring-server "0.2.6"]))
 
 (defn server-task
   "Shared logic for server and server-headless tasks."
   [project options]
   (ensure-handler-set! project)
-  (let [project (update-in project [:ring] merge options)]
+  (let [options (assoc options :reload-paths (src-paths project))
+        project (update-in project [:ring] merge options)]
     (eval-in-project
      (add-server-dep project)
      `(ring.server.leiningen/serve

--- a/src/leiningen/ring/src_paths.clj
+++ b/src/leiningen/ring/src_paths.clj
@@ -1,0 +1,62 @@
+(ns leiningen.ring.src-paths
+  (:require [clojure.java.io :as io]
+            [leiningen.core.project :as lp]))
+
+;; code is modified from leiningen.core.classpath
+
+(defn read-dependency-project [root dep]
+  (let [project-file (io/file root "checkouts" dep "project.clj")]
+    (if (.exists project-file)
+      (let [project (.getCanonicalPath project-file)]
+        (try (lp/read project [])
+          (catch Exception e
+            (throw (Exception. (format "Problem loading %s" project) e)))))
+      (println
+        "WARN ignoring checkouts directory" dep
+        "as it does not contain a project.clj file."))))
+
+(defn project-src-paths 
+  "extract source paths for a single project. Merges lein1 and lein2 paths"
+  [project]
+  (cons
+    (:source-path project)   ; lein1
+    (:source-paths project)  ; lein2
+    ))
+
+(defn checkout-src-paths 
+  "extract source paths for all checkouts of a project
+   this does not recurse through projects to find all checkouts
+   (same as leiningen's classpath)"
+  [project]
+  (apply concat
+         (for [dep (.list (io/file (:root project) "checkouts"))
+               :let [dep-project (read-dependency-project
+                                   (:root project) dep)]
+               :when dep-project]
+           (project-src-paths dep-project))))
+
+;; this function should be used if leiningen changes to include 
+;; recursive checkouts on it's classpath. Currently, it does not.
+#_(defn recursive-checkout-src-paths 
+  "extract source paths for all checkouts of a project
+   this does recurse through projects to find all checkouts"
+  [project]
+  (apply concat
+         (for [dep (.list (io/file (:root project) "checkouts"))
+               :let [dep-project (read-dependency-project
+                                   (:root project) dep)]
+               :when dep-project]
+           (concat
+             (project-src-paths dep-project)
+             (recursive-checkout-src-paths dep-project)
+             ))))
+
+(defn src-paths
+  "extract source paths from project and it's checkouts projects"
+  [project]
+  ;; remove duplicates and possible nil
+  (-> #{}
+    (into (project-src-paths project))
+    (into (checkout-src-paths project))
+    (disj nil)
+    seq))


### PR DESCRIPTION
Added: leiningen.ring.src-paths

Searches project for source-paths.

This only searches the immediate project checkouts dir,
the same as leiningen uses for it's classpath.

Changed: leiningen.ring.server

src-paths are passed to ring.server.leiningen/serve in options.
These are always provided. It is slightly problematic to determine whether
they are needed as ring-server determines from LEIN_NO_DEV env
variable whether to use reloading or not.

Preemptively updated ring-server add-if-missing to ring-server 0.2.6
