### PR TITLE
Support multiple war-resources-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ However, there is another sort of resource, one accessed through the
 `ServletContext` object. These resources are usually not on the classpath,
 and are instead placed in the root of the war file. If you happen to need this
 functionality, you can place your files in the directory specified by the
-`:war-resources-path` key, which defaules to "war-resources". It's recommended
-that you only use WAR resources for compatibility with legacy Java interfaces;
-under most circumstances, you should use the normal `:resources-path` instead.
+`:war-resources-path` key, which defaults to "war-resources". (As with
+normal resources, here you can use `:war-resource-paths` to include multiple
+directories.) It's recommended that you only use WAR resources for
+compatibility with legacy Java interfaces; under most circumstances, you
+should use the normal `:resources-path` instead.

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -37,7 +37,8 @@
                                    [(:resources-path project)] (:resource-paths project)))
             :when path]
       (war/dir-entry war-stream project "WEB-INF/classes/" path))
-    (war/dir-entry war-stream project "" (war/war-resources-path project))
+    (doseq [path (war/war-resources-paths project)]
+      (war/dir-entry war-stream project "" path))
     (jar-entries war-stream project)))
 
 (defn uberwar

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -180,8 +180,9 @@
     (let [war-path (in-war-path war-root dir-path file)]
       (file-entry war project war-path file))))
 
-(defn war-resources-path [project]
-  (:war-resources-path project "war-resources"))
+(defn war-resources-paths [project]
+  (filter identity
+    (distinct (concat [(:war-resources-path project "war-resources")] (:war-resource-paths project)))))
 
 (defn write-war [project war-path]
   (with-open [war-stream (create-war project war-path)]
@@ -192,7 +193,8 @@
                                    [(:resources-path project)] (:resource-paths project)))
             :when path]
       (dir-entry war-stream project "WEB-INF/classes/" path))
-    (dir-entry war-stream project "" (war-resources-path project))
+    (doseq [path (war-resources-paths project)]
+      (dir-entry war-stream project "" path))
     war-stream))
 
 (defn add-servlet-dep [project]


### PR DESCRIPTION
We currently support multiple resource-paths by doing (concat (:resources-path project)). We support the same for source-paths. It would be super useful to also support multiple war-resources-paths in the same way (so that multiple activated profiles can bring in different sets of war-resources composably).

My use case currently is that I have one set of war-resources that need to be brought in conditionally based on a profile-activated choice of authentication strategy (legacy J2EE authentication or not), and one set that needs to be brought in based on choice of JBoss version. Right now I've got to maintain m*n sets of resources where I could be maintaining m+n with this option.

Patch: Allows support for multiple war-resource-paths via the same mechanism used for resource-paths. Only difference is that this was pulled out into a separate function for uberjar's use, so instead of (doseq :when) we need to use (filter identity) to avoid duplicating the (doseq :when) logic.
