### PR TITLE
Explain clojure.main OS X dock icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ it doesn't open a web browser:
 
     lein ring server-headless 4000
 
+N.B. `lein ring server` opens an icon in the OS X dock titled "clojure.main", 
+whereas `lein ring server-headless` does not. This is because it uses 
+[`clojure.java.browse/browse-url`](http://clojuredocs.org/clojure_core/clojure.java.browse/browse-url).
 
 ## Web server options
 


### PR DESCRIPTION
I wondered why I had a dock icon for clojure.main. 
It turned out to be the difference between `lein ring server` and 
`lein ring server-headless`. 

For anybody else wondering about that, a mention in the README 
would be useful I thought.
