### PR TITLE
ring-server dependency is not picked up by leinjacker

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -27,7 +27,7 @@
       (classpath-dirs project)))
 
 (defn add-server-dep [project]
-  (update-project project deps/add-if-missing '[ring-server "0.2.8"]))
+  (update-project project deps/add-if-missing '[ring-server/ring-server "0.2.8"]))
 
 (defn server-task
   "Shared logic for server and server-headless tasks."


### PR DESCRIPTION
Because dependency names are expanded in leinjacker, when testing to see if the ring-server dependency is already present, it fails, thus preventing adding exclusions for ring-server if necessary (for example, if testing ring 1.2.0-beta2).

(https://github.com/sattvik/leinjacker/blob/master/src/leinjacker/deps.clj#L41)

I'm not sure this is the best way to handle this--it may make more sense to do a pull request for leinjacker, making dependency matching more robust--but this works and is pretty minimal.
