### PR TITLE
nREPL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,10 @@ The following options affect the behavior of the web server started by
   If true, automatically refresh the browser when source or resource
   files are modified. Defaults to false.
 
-* `:start-repl?` - 
-  If true, starts an nREPL server in the same process as the web server. 
-  Defaults to false.
-
-* `:repl-port` - 
-  The port to start the nREPL server on. Defaults to an arbitrary free port.
+* `:nrepl` - 
+  A map of `:start?` and (optionally) `:port` keys. If `:start?` is true, 
+  open up an nREPL server on the given port. `:start?` defaults to false, 
+  `:port` defaults to an arbitrary free port.
 
 ## Executable jar files
 

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,5 @@
   :url "https://github.com/weavejester/lein-ring"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.clojure/data.xml "0.0.6"]
-                 [org.clojure/tools.nrepl "0.2.2"]
                  [leinjacker "0.4.1"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
Hi James - as discussed, have added in nREPL support to the `lein ring server` etc commands. 

Have updated the docs, and verified that the code is correct with:

``` clojure
(server-task (-> my-project
                 (assoc-in [:ring :start-repl?] true)
                 (assoc-in [:ring :repl-port] 7000))
             {})
```

where `my-project` was a project.clj map that I pulled from another project with leinjacker.

Let me know if this is the right place to put this functionality, or if there's any other changes you'd like me to make!

James
