### PR TITLE
Add javax.servlet/servlet-api dependency

### DIFF
--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -1,6 +1,7 @@
 (ns leiningen.ring.uberwar
   (:use leiningen.ring.util)
   (:require [leiningen.ring.war :as war]
+            [leinjacker.deps :as deps]
             [leiningen.compile :as compile]
             [clojure.java.io :as io]
             [leinjacker.utils :as lju])
@@ -55,6 +56,9 @@
     (unmerge-fn project [:default])
     project))
 
+(defn- add-servlet-dep [project]
+  (update-project project deps/add-if-missing '[javax.servlet/servlet-api "2.5"]))
+
 (defn uberwar
   "Create a $PROJECT-$VERSION.war with dependencies."
   ([project]
@@ -62,6 +66,7 @@
   ([project war-name]
      (ensure-handler-set! project)
      (let [project (-> project
+                       add-servlet-dep
                        unmerge-profiles
                        war/add-servlet-dep)
            result  (compile/compile project)]


### PR DESCRIPTION
Since servlet-api is now a provided dependency in ring, we need to add this as a dependency before compiling the servlet in the uberwar task - otherwise we get compilation errors.
