### PR TITLE
Pass context to init/destroy listeners if asked.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-ring "0.8.7"
+(defproject org.clojars.abbot/lein-ring "0.8.7"
   :description "Leiningen Ring plugin"
   :url "https://github.com/weavejester/lein-ring"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Sometimes it is required to do something in init/destroy listener depending on servlet context (e.g. load specific configuration bits).

This commit adds an ring option :listeners-with-ctx. If set to true, init and destroy
handlers will be called with a servlet context argument.