### PR TITLE
Remove dev dependencies from the constructed war

### DIFF
--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -214,7 +214,6 @@
      (war project (default-war-name project)))
   ([project war-name]
      (ensure-handler-set! project)
-;     (let [project (add-servlet-dep project)
       (let [project (-> project
                         add-servlet-dep
                         unmerge-profiles)


### PR DESCRIPTION
"lein ring war" includes all dev dependencies and resources when constructing the war file.
To remove all the project dev stuff from the war file, I used the same solution implemented
with pull request #62 (uberwar dev deps): https://github.com/weavejester/lein-ring/pull/62
