### PR TITLE
Write nrepl port into target/repl-port

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -46,10 +46,11 @@
 (defn start-nrepl-expr [project]
   (let [port (-> project :ring :nrepl (:port 0))]
     `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port)]
-       (-> "target/repl-port"
-           java.io.File.
-           (#(do (.deleteOnExit %) %))
-           (spit port#))
+       (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
+         (-> port-file#
+             java.io.File.
+             (doto .deleteOnExit)
+             (spit port#)))
        (println "Started nREPL server on port" port#))))
 
 (defn server-task


### PR DESCRIPTION
Allows nrepl/cider port discovery with {:nrepl {:start? true}}
