### PR TITLE
add generated main to aot

### DIFF
--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -29,7 +29,9 @@
   (update-project project assoc :main (symbol (main-namespace project))))
 
 (defn verify-main-in-aot [project]
-  (update-project project update-in [:aot] (fn [aot] (or aot [(symbol (main-namespace project))]))))
+  (if-not (or (get-in project [:aot]) (get-in project [:profiles :uberjar :aot]))
+    (update-project project assoc :aot [(symbol (main-namespace project))])
+    project))
 
 (defn jar
   "Create an executable $PROJECT-$VERSION.jar file."

--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -28,6 +28,9 @@
 (defn add-main-class [project]
   (update-project project assoc :main (symbol (main-namespace project))))
 
+(defn verify-main-in-aot [project]
+  (update-project project update-in [:aot] (fn [aot] (or aot [(symbol (main-namespace project))]))))
+
 (defn jar
   "Create an executable $PROJECT-$VERSION.jar file."
   [project]

--- a/src/leiningen/ring/uberjar.clj
+++ b/src/leiningen/ring/uberjar.clj
@@ -8,6 +8,6 @@
   "Create an executable $PROJECT-$VERSION.jar file with dependencies."
   [project]
   (ensure-handler-set! project)
-  (let [project (-> project add-server-dep jar/add-main-class)]
+  (let [project (-> project add-server-dep jar/add-main-class jar/verify-main-in-aot)]
     (jar/compile-main project)
     (leiningen.uberjar/uberjar project)))


### PR DESCRIPTION
enabling generated main to have aot in ```lein ring uberjar``` to avoid:

```
Warning: specified :main without including it in :aot.
Implicit AOT of :main will be removed in Leiningen 3.0.0.
If you only need AOT for your uberjar, consider adding :aot :all into your
:uberjar profile instead.
```
(Leiningen 2.3.4)

regards,

Tommi