### PR TITLE
Activate uberjar profile before compiling the uberjar

### DIFF
--- a/src/leiningen/ring/uberjar.clj
+++ b/src/leiningen/ring/uberjar.clj
@@ -1,7 +1,8 @@
 (ns leiningen.ring.uberjar
   (:use [leiningen.ring.util :only (ensure-handler-set!)]
         [leiningen.ring.server :only (add-server-dep)])
-  (:require [leiningen.ring.jar :as jar]
+  (:require [leiningen.core.project :as project]
+            [leiningen.ring.jar :as jar]
             leiningen.uberjar))
 
 (defn uberjar
@@ -9,5 +10,6 @@
   [project]
   (ensure-handler-set! project)
   (let [project (-> project add-server-dep jar/add-main-class)]
-    (jar/compile-main project)
+    (let [project (project/merge-profiles project [:uberjar])]
+      (jar/compile-main project))
     (leiningen.uberjar/uberjar project)))


### PR DESCRIPTION
This makes sure any items in the :ring map for the uberjar profile get added to the main class in the compiled uberjar