### PR TITLE
Write correct attributes into web.xml to say which version of the servlet spec we conform to

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ The following war-specific options are supported:
 * `:web-xml` -
   web.xml file to use in place of auto-generated version (relative to project root).
 
+* `:servlet-version` -
+  The version of the servlet spec that we claim to conform
+  to. Attributes corresponding to this version will be added to the
+  web-app element of the web.xml. If not specified, defaults to 2.5.
+
 These keys should be placed under the `:ring` key in `project.clj`,
 and are optional values. If not supplied, default values will be used instead.
 

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -96,6 +96,26 @@
   (or (get-in project [:ring :url-pattern])
       "/*"))
 
+(def web-app-attrs
+  "Attributes for the web-app element, indexed by the servlet version."
+  {"2.4" {:xmlns     "http://java.sun.com/xml/ns/j2ee"
+          :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+          :xsi:schemaLocation (str "http://java.sun.com/xml/ns/j2ee "
+                                   "http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd")
+          :version "2.4"}
+   "2.5" {:xmlns     "http://java.sun.com/xml/ns/javaee"
+          :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+          :xsi:schemaLocation (str "http://java.sun.com/xml/ns/javaee "
+                                   "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd")
+          :version "2.5"}
+   "3.0" {:xmlns     "http://java.sun.com/xml/ns/javaee"
+          :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+          :xsi:schemaLocation (str "http://java.sun.com/xml/ns/javaee "
+                                   "http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd")
+          :version "3.0"}})
+
+(def default-servlet-version "2.5")
+
 (defn make-web-xml [project]
   (let [ring-options (:ring project)]
     (if (contains? ring-options :web-xml)
@@ -103,6 +123,9 @@
       (indent-str
         (sexp-as-element
           [:web-app
+           (get web-app-attrs
+                (get-in project [:ring :servlet-version] default-servlet-version)
+                {})
            (if (has-listener? project)
              [:listener
               [:listener-class (listener-class project)]])


### PR DESCRIPTION
Hi James,

I was having trouble getting an uberjar created by lein-ring to run in a WebSphere Liberty app server. It turns out that the web.xml wasn't conforming with the servlet spec; it didn't specify the version and associated namespace on the <web-app> element. Reading through the spec, it looks like this is required to be included and Liberty was refusing to run the web app without it.

For example, the following is required by version 2.5 of the spec:

<web-app xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        version="2.5"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">

The code change in this pull request adds an extra key to the :ring section of project.clj called :servlet-version. lein ring uberjar then spits out the correct web-app attributes for the version of the spec that you specify, provided that version is 2.4, 2.5 or 3.0. Note that I haven't made any effort to make the app conform to the spec in any other way; this change just makes the web.xml _claim_ that it conforms to a particular version of the spec.

For each of these versions, the resulting uberwar file runs successfully in my WebSphere Liberty 8.5.5 server.

Please let me know if you'd be willing to include this patch or if I need to make any changes to it (and please be patient with me because this is my first contribution to a Clojure project :-).
