### PR TITLE
Release version 0.8.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Ring handler into a standard war file.
 To use Lein-Ring, add it as a plugin to your `project.clj` file or
 your global profile:
 
-    :plugins [[lein-ring "0.8.10"]]
+    :plugins [[lein-ring "0.8.11"]]
 
 Or, if you are using a version of Leiningen prior to 1.7.0:
 
-    :dev-dependencies [[lein-ring "0.8.10"]]
+    :dev-dependencies [[lein-ring "0.8.11"]]
 
 Then add a new `:ring` key to your `project.clj` file that contains a
 map of configuration options. At minimum there must be a `:handler`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-ring "0.8.10"
+(defproject lein-ring "0.8.11"
   :description "Leiningen Ring plugin"
   :url "https://github.com/weavejester/lein-ring"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
As discussed, this patch increments the version number to 0.8.11. I've briefly tested that this level of code can create uberwars that load ok into the latest versions of Liberty and Tomcat.

@weavejester, assuming it looks ok to you, please could you merge and push to clojars?
