### PR TITLE
Fixed issue #109: lein ring uberwar ignores project :omit-source.

### DIFF
--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -43,8 +43,7 @@
     (doto war-stream
       (war/str-entry "WEB-INF/web.xml" (war/make-web-xml project))
       (war/dir-entry project "WEB-INF/classes/" (:compile-path project)))
-    (doseq [path (distinct (concat [(:source-path project)] (:source-paths project)
-                                   [(:resources-path project)] (:resource-paths project)))
+    (doseq [path (source-and-resource-paths project)
             :when path]
       (war/dir-entry war-stream project "WEB-INF/classes/" path))
     (doseq [path (war/war-resources-paths project)]

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -45,3 +45,13 @@
   (vary-meta
    (apply func project args)
    update-in [:without-profiles] #(apply func % args)))
+
+(defn source-and-resource-paths
+  "Return a distinct sequence of the project's source and resource paths,
+  unless :omit-source is true, in which case return only resource paths."
+  [project]
+  (let [resource-paths (concat [(:resources-path project)] (:resource-paths project))
+        source-paths (if (:omit-source project)
+                       '()
+                       (concat [(:source-path project)] (:source-paths project)))]
+    (distinct (concat source-paths resource-paths))))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -214,8 +214,7 @@
     (doto war-stream
       (str-entry "WEB-INF/web.xml" (make-web-xml project))
       (dir-entry project "WEB-INF/classes/" (:compile-path project)))
-    (doseq [path (distinct (concat [(:source-path project)] (:source-paths project)
-                                   [(:resources-path project)] (:resource-paths project)))
+    (doseq [path (source-and-resource-paths project)
             :when path]
       (dir-entry war-stream project "WEB-INF/classes/" path))
     (doseq [path (war-resources-paths project)]


### PR DESCRIPTION
Please consider this fix for issue #109.

There's a new utility that lists source and resource paths, omitting source paths if the project specifies so. This utility is used by the uberwar and war commands.
