### PR TITLE
Option to add nREPL middleware.

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -44,8 +44,10 @@
     project))
 
 (defn start-nrepl-expr [project]
-  (let [port (-> project :ring :nrepl (:port 0))]
-    `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port)]
+  (let [port (-> project :ring :nrepl (:port 0))
+        middlewares (map (fn [m] `#'~m) (-> project :ring :nrepl (:middlewares [])))]
+    `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port
+                                                                  :handler (clojure.tools.nrepl.server/default-handler ~@middlewares))]
        (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
          (-> port-file#
              java.io.File.


### PR DESCRIPTION
This PR allows the project to specify nREPL middleware to add to the stack when launching an nREPL.

As I understand it, there's no way to get [Piggieback](https://github.com/cemerick/piggieback) to work without adding this middleware. I could run a separate REPL, but that doesn't let you set up Piggieback and fireplace.vim (and, I expect, the equivalent in other editors) as easily. I pushed [a repo with my initial, failed attempt to make that work](https://github.com/Peeja/fireplace-brepl-demo/).

I'd kind of like to just use the `:repl-options {:nrepl-middleware ...}` value, but I felt weird reaching over and yanking on that config. Might still be the right thing to do. Really, I'd prefer it if lein-ring would launch its nREPL by calling the same code that `leiningen.repl` uses, but the function we'd need (`leiningen.repl/server-forms`) is private. Maybe it's worth asking Leiningen to change that? What do you think?

In any case, I'll add documentation as well, but I wanted to run the code changes up the flagpole first and see the response.