### PR TITLE
Avoid AOT compilation of project code

### DIFF
--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -1,5 +1,6 @@
 (ns leiningen.ring.jar
-  (:use [leiningen.ring.util :only (compile-form ensure-handler-set! update-project)]
+  (:use [leiningen.ring.util :only (compile-form ensure-handler-set!
+                                    update-project require-and-resolve)]
         [leiningen.ring.server :only (add-server-dep)])
   (:require [clojure.string :as str]
             leiningen.jar))
@@ -20,10 +21,9 @@
                     (assoc-in [:ring :auto-reload?] false))]
     (compile-form project main-ns
       `(do (ns ~main-ns
-             (:require ring.server.leiningen)
              (:gen-class))
            (defn ~'-main []
-             (ring.server.leiningen/serve '~options))))))
+             (~(require-and-resolve 'ring.server.leiningen/serve) '~options))))))
 
 (defn add-main-class [project]
   (update-project project assoc :main (symbol (main-namespace project))))

--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -1,6 +1,6 @@
 (ns leiningen.ring.jar
   (:use [leiningen.ring.util :only (compile-form ensure-handler-set!
-                                    update-project require-and-resolve)]
+                                    update-project generate-resolve)]
         [leiningen.ring.server :only (add-server-dep)])
   (:require [clojure.string :as str]
             leiningen.jar))
@@ -23,7 +23,7 @@
       `(do (ns ~main-ns
              (:gen-class))
            (defn ~'-main []
-             (~(require-and-resolve 'ring.server.leiningen/serve) '~options))))))
+             (~(generate-resolve 'ring.server.leiningen/serve) '~options))))))
 
 (defn add-main-class [project]
   (update-project project assoc :main (symbol (main-namespace project))))

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -69,8 +69,7 @@
        (when-not (and (number? result) (pos? result))
          (let [war-path (war/war-file-path project war-name)]
            (war/compile-servlet project)
-           (if (war/has-listener? project)
-             (war/compile-listener project))
+           (war/compile-listener project)
            (write-uberwar project war-path)
            (println "Created" war-path)
            war-path)))))

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -4,7 +4,7 @@
             [clojure.java.io :as io]
             leiningen.deps))
 
-(defn require-and-resolve [qual-sym]
+(defn generate-resolve [qual-sym]
   `(try
      (require (quote ~(symbol (namespace qual-sym))))
      (or

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -5,9 +5,12 @@
             leiningen.deps))
 
 (defn require-and-resolve [qual-sym]
-  `(do
+  `(try
      (require (quote ~(symbol (namespace qual-sym))))
-     (resolve (quote ~qual-sym))))
+     (resolve (quote ~qual-sym))
+     (catch Exception e#
+       (.printStackTrace e#)
+       (throw e#))))
 
 (defn ensure-handler-set!
   "Ensure the :handler option is set in the project map."

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -4,6 +4,11 @@
             [clojure.java.io :as io]
             leiningen.deps))
 
+(defn require-and-resolve [qual-sym]
+  `(do
+     (require (quote ~(symbol (namespace qual-sym))))
+     (resolve (quote ~qual-sym))))
+
 (defn ensure-handler-set!
   "Ensure the :handler option is set in the project map."
   [project]

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -4,15 +4,21 @@
             [clojure.java.io :as io]
             leiningen.deps))
 
+(defn assert-vars-exist [project & var-syms]
+  (eval-in-project
+    project
+    (into [] var-syms)
+    `(require '[~@(->>
+                    var-syms
+                    (filter identity)
+                    (map namespace)
+                    (map symbol)
+                    distinct)])))
+
 (defn generate-resolve [qual-sym]
-  `(try
-     (require (quote ~(symbol (namespace qual-sym))))
-     (or
-       (resolve (quote ~qual-sym))
-       (throw (Exception. ~(str "could not locate var " qual-sym))))
-     (catch Exception e#
-       (.printStackTrace e#)
-       (throw e#))))
+  `(do
+     (require '~(symbol (namespace qual-sym)))
+     (resolve '~qual-sym)))
 
 (defn ensure-handler-set!
   "Ensure the :handler option is set in the project map."

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -7,7 +7,9 @@
 (defn require-and-resolve [qual-sym]
   `(try
      (require (quote ~(symbol (namespace qual-sym))))
-     (resolve (quote ~qual-sym))
+     (or
+       (resolve (quote ~qual-sym))
+       (throw (Exception. ~(str "could not locate var " qual-sym))))
      (catch Exception e#
        (.printStackTrace e#)
        (throw e#))))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -156,6 +156,7 @@
         handler-sym (get-in project [:ring :handler])
         servlet-ns  (servlet-ns project)
         project-ns  (symbol (listener-ns project))]
+    (assert-vars-exist project init-sym destroy-sym handler-sym)
     (compile-form project project-ns
       `(do (ns ~project-ns
              (:gen-class :implements [javax.servlet.ServletContextListener]))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -70,7 +70,8 @@
 
 (defn default-listener-class [project]
   (let [listener-sym (or (get-in project [:ring :init])
-                         (get-in project [:ring :destroy]))
+                         (get-in project [:ring :destroy])
+                         (get-in project [:ring :handler]))
         ns-parts     (-> (namespace listener-sym)
                          (string/replace "-" "_")
                          (string/split #"\.")

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -132,14 +132,14 @@
 
 (defn generate-handler [project handler-sym]
   (if (get-in project [:ring :servlet-path-info?] true)
-    `(let [handler# ~(require-and-resolve handler-sym)]
+    `(let [handler# ~(generate-resolve handler-sym)]
        (fn [request#]
          (let [context# ^String (.getContextPath (:servlet-request request#))]
            (handler#
             (assoc request#
               :context context#
               :path-info (-> (:uri request#) (subs (.length context#)) not-empty (or "/")))))))
-    (require-and-resolve handler-sym)))
+    (generate-resolve handler-sym)))
 
 (defn compile-servlet [project]
   (let [servlet-ns  (symbol (servlet-ns project))]
@@ -163,17 +163,17 @@
               `(do
                  (defn ~'-contextInitialized [this# ~servlet-context-event]
                    ~(if init-sym
-                      `(~(require-and-resolve init-sym)))
+                      `(~(generate-resolve init-sym)))
                    (let [handler# ~(generate-handler project handler-sym)
-                         make-service-method# ~(require-and-resolve
+                         make-service-method# ~(generate-resolve
                                                  'ring.util.servlet/make-service-method)
                          method# (make-service-method# handler#)]
                      (alter-var-root
-                       ~(require-and-resolve (symbol servlet-ns "service-method"))
+                       ~(generate-resolve (symbol servlet-ns "service-method"))
                        (constantly method#))))
                  (defn ~'-contextDestroyed [this# ~servlet-context-event]
                    ~(if destroy-sym
-                      `(~(require-and-resolve destroy-sym))))))))))
+                      `(~(generate-resolve destroy-sym))))))))))
 
 (defn create-war [project file-path]
   (-> (FileOutputStream. file-path)


### PR DESCRIPTION
This pull request reduces AOT compilation when compiling wars or jars. It AOT compiles only the generated servlet/listener namespaces, which act as shims, only importing the user's code or ring.util.servlet at runtime.

The service method gets stuffed in a var at init time and is read from there after that.

This more or less incidentally sorts out https://github.com/ring-clojure/ring/issues/166 -- the thing that gets stuffed in the var is the result of calling make-service-method.
