### PR TITLE
Use nrepl options middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-ring "0.8.13"
+(defproject lein-ring "0.8.14-SNAPSHOT"
   :description "Leiningen Ring plugin"
   :url "https://github.com/weavejester/lein-ring"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-ring "0.8.14-SNAPSHOT"
+(defproject lein-ring "0.8.13"
   :description "Leiningen Ring plugin"
   :url "https://github.com/weavejester/lein-ring"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -54,7 +54,9 @@
 (defn start-nrepl-expr [project]
   (let [port (-> project :ring :nrepl (:port 0))
         handler (nrepl-handler (nrepl-middleware project))]
-    `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port :handler ~handler)]
+    `(let [{port# :port} (clojure.tools.nrepl.server/start-server
+                          :port ~port
+                          :handler ~handler)]
        (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
          (-> port-file#
              java.io.File.
@@ -87,6 +89,6 @@
 (defn server
   "Start a Ring server and open a browser."
   ([project]
-   (server-task project {}))
+     (server-task project {}))
   ([project port]
-   (server-task project {:port (Integer. port)})))
+     (server-task project {:port (Integer. port)})))

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -5,7 +5,7 @@
   (:use [leinjacker.eval :only (eval-in-project)]
         [leiningen.ring.util :only (ensure-handler-set! update-project)]))
 
-(defn classpath-dirs 
+(defn classpath-dirs
   "list of all dirs on the leiningen classpath"
   [project]
   (filter
@@ -44,8 +44,9 @@
     project))
 
 (defn start-nrepl-expr [project]
-  (let [port (-> project :ring :nrepl (:port 0))]
-    `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port)]
+  (let [port (-> project :ring :nrepl (:port 0))
+        middleware (-> project :ring :nrepl :nrepl-middleware)]
+    `(let [{port# :port} (clojure.tools.nrepl.server/start-server :port ~port :handler (apply clojure.tools.nrepl.server/default-handler middleware))]
        (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
          (-> port-file#
              java.io.File.

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -76,15 +76,13 @@
      (if (nrepl? project)
        `(do ~(start-nrepl-expr project) ~(start-server-expr project))
        (start-server-expr project))
-     (apply load-namespaces
-            (let [load-ns ['ring.server.leiningen
-                           (if (nrepl? project) 'clojure.tools.nrepl.server)
-                           (-> project :ring :handler)
-                           (-> project :ring :init)
-                           (-> project :ring :destroy)]]
-              (if (nrepl? project)
-                (into load-ns (nrepl-middleware project))
-                load-ns))))))
+     (load-namespaces
+      'ring.server.leiningen
+      (if (nrepl? project) 'clojure.tools.nrepl.server)
+      (if (nrepl? project) (nrepl-middleware project))
+      (-> project :ring :handler)
+      (-> project :ring :init)
+      (-> project :ring :destroy)))))
 
 (defn server
   "Start a Ring server and open a browser."


### PR DESCRIPTION
Utilize :nrepl-middleware for Ring's nREPL

Makes 'lein ring server' honor :nrepl-middleware specified in :repl-options, optionally overriden directly in the :ring option map.

Possibly conflicts with #118 or might supercede it - I don't use Cider.

Example usage (with LightTable nREPL middleware):

```clojure
;;project.clj

(defproject my-app "0.1.0-SNAPSHOT"
:ring {:handler my-app.core/handler
         :nrepl {:start? true
                 :nrepl-middleware [lighttable.nrepl.handler/lighttable-ops]}} ;; overrides below

;;or

:repl-options {:nrepl-middleware [lighttable.nrepl.handler/lighttable-ops]})
```
