### PR TITLE
Load stacktrace middleware namespace.

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -70,7 +70,8 @@
       (if (nrepl? project) 'clojure.tools.nrepl.server)
       (-> project :ring :handler)
       (-> project :ring :init)
-      (-> project :ring :destroy)))))
+      (-> project :ring :destroy)
+      (-> project :ring :stacktrace-middleware)))))
 
 (defn server
   "Start a Ring server and open a browser."


### PR DESCRIPTION
To go with the new ring-server option to supply a different stacktrace
handler than the default.

See https://github.com/weavejester/ring-server/pull/21

I noticed that `:init` and `:destroy` also got some special treatment in `war.clj`, but that seemed very specific to those features. I couldn't quite figure out if or how this would fit. In my case, custom stack traces is a thing of the `:dev` profile anyway. Any thoughts?