### PR TITLE
Enable the uberjar profile for the uberjar/uberwar tasks.

### DIFF
--- a/src/leiningen/ring/uberjar.clj
+++ b/src/leiningen/ring/uberjar.clj
@@ -1,5 +1,6 @@
 (ns leiningen.ring.uberjar
-  (:use [leiningen.ring.util :only (ensure-handler-set!)]
+  (:use [leiningen.ring.util :only [ensure-handler-set! merge-profiles
+                                    unmerge-profiles]]
         [leiningen.ring.server :only (add-server-dep)])
   (:require [leiningen.ring.jar :as jar]
             [leiningen.clean :as clean]
@@ -23,8 +24,13 @@
   "Create an executable $PROJECT-$VERSION.jar file with dependencies."
   [project]
   (ensure-handler-set! project)
-  (when (:auto-clean project true)
-    (clean/clean project))
-  (let [project (-> project add-server-dep jar/add-main-class no-uberjar-clean)]
+  (let [project (-> project
+                    (unmerge-profiles [:default])
+                    (merge-profiles [:uberjar])
+                    add-server-dep
+                    jar/add-main-class
+                    no-uberjar-clean)]
+    (when (:auto-clean project true)
+      (clean/clean project))
     (jar/compile-main project)
     (leiningen.uberjar/uberjar project)))

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -3,8 +3,7 @@
   (:require [leiningen.ring.war :as war]
             [leinjacker.deps :as deps]
             [leiningen.compile :as compile]
-            [clojure.java.io :as io]
-            [leinjacker.utils :as lju])
+            [clojure.java.io :as io])
   (:import [java.util.jar JarFile JarEntry]))
 
 (defn default-uberwar-name [project]
@@ -50,12 +49,6 @@
       (war/dir-entry war-stream project "" path))
     (jar-entries war-stream project)))
 
-(defn unmerge-profiles [project]
-  (if-let [unmerge-fn (and (= 2 (lju/lein-generation))
-                           (lju/try-resolve 'leiningen.core.project/unmerge-profiles))]
-    (unmerge-fn project [:default])
-    project))
-
 (defn uberwar
   "Create a $PROJECT-$VERSION.war with dependencies."
   ([project]
@@ -63,7 +56,8 @@
   ([project war-name]
      (ensure-handler-set! project)
      (let [project (-> project
-                       unmerge-profiles
+                       (unmerge-profiles [:default])
+                       (merge-profiles [:uberjar])
                        war/add-servlet-dep)
            result  (compile/compile project)]
        (when-not (and (number? result) (pos? result))

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -2,7 +2,8 @@
   (:use [leinjacker.eval :only (eval-in-project)])
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
-            leiningen.deps))
+            [leiningen.deps]
+            [leinjacker.utils :as lju]))
 
 (defn ensure-handler-set!
   "Ensure the :handler option is set in the project map."
@@ -55,3 +56,15 @@
                        '()
                        (concat [(:source-path project)] (:source-paths project)))]
     (distinct (concat source-paths resource-paths))))
+
+(defn unmerge-profiles [project profiles]
+  (if-let [unmerge-fn (and (= 2 (lju/lein-generation))
+                           (lju/try-resolve 'leiningen.core.project/unmerge-profiles))]
+    (unmerge-fn project profiles)
+    project))
+
+(defn merge-profiles [project profiles]
+  (if-let [merge-fn (and (= 2 (lju/lein-generation))
+                         (lju/try-resolve 'leiningen.core.project/merge-profiles))]
+    (merge-fn project profiles)
+    project))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -221,12 +221,6 @@
       (dir-entry war-stream project "" path))
     war-stream))
 
-(defn unmerge-profiles [project]
-  (if-let [unmerge-fn (and (= 2 (lju/lein-generation))
-                           (lju/try-resolve 'leiningen.core.project/unmerge-profiles))]
-    (unmerge-fn project [:default])
-    project))
-
 (defn add-servlet-dep [project]
   (-> project
       (deps/add-if-missing '[ring/ring-servlet "1.2.1"])
@@ -239,7 +233,7 @@
   ([project war-name]
      (ensure-handler-set! project)
       (let [project (-> project
-                        unmerge-profiles
+                        (unmerge-profiles [:default])
                         add-servlet-dep)
            result  (compile/compile project)]
        (when-not (and (number? result) (pos? result))


### PR DESCRIPTION
This will unmerge the default profile and merge in the uberjar profile (in a similar way to what the leiningen uberjar task does).

This fixes the issue with lein-ring not respecting the :target-path configuration. This should fix #116 and #129.