### PR TITLE
Fix bug with passing vector instead of namespace.

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -76,13 +76,15 @@
      (if (nrepl? project)
        `(do ~(start-nrepl-expr project) ~(start-server-expr project))
        (start-server-expr project))
-     (load-namespaces
-      'ring.server.leiningen
-      (if (nrepl? project) 'clojure.tools.nrepl.server)
-      (if (nrepl? project) (nrepl-middleware project))
-      (-> project :ring :handler)
-      (-> project :ring :init)
-      (-> project :ring :destroy)))))
+     (apply load-namespaces
+            (let [load-ns ['ring.server.leiningen
+                           (if (nrepl? project) 'clojure.tools.nrepl.server)
+                           (-> project :ring :handler)
+                           (-> project :ring :init)
+                           (-> project :ring :destroy)]]
+              (if (nrepl? project)
+                (into load-ns (nrepl-middleware project))
+                load-ns))))))
 
 (defn server
   "Start a Ring server and open a browser."


### PR DESCRIPTION
this commit from https://github.com/weavejester/lein-ring/pull/138 tries to simplify the logic, but in this line 
```clojure
(if (nrepl? project) (nrepl-middleware project))
```
we've got an array instead of namespace,it was ```into``` in previous version... I think there's nothing to do w/o ```apply``` here (correct me if i'm not right, i'm quite new in clojure), so in my opinion better to live the old code. 