### PR TITLE
Correctly handle nrepl-middleware vector in load-namespaces

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -76,13 +76,14 @@
      (if (nrepl? project)
        `(do ~(start-nrepl-expr project) ~(start-server-expr project))
        (start-server-expr project))
-     (load-namespaces
-      'ring.server.leiningen
-      (if (nrepl? project) 'clojure.tools.nrepl.server)
-      (if (nrepl? project) (nrepl-middleware project))
-      (-> project :ring :handler)
-      (-> project :ring :init)
-      (-> project :ring :destroy)))))
+     (apply load-namespaces
+            (conj (into
+                   ['ring.server.leiningen
+                    (if (nrepl? project) 'clojure.tools.nrepl.server)]
+                   (if (nrepl? project) (nrepl-middleware project)))
+                  (-> project :ring :handler)
+                  (-> project :ring :init)
+                  (-> project :ring :destroy))))))
 
 (defn server
   "Start a Ring server and open a browser."


### PR DESCRIPTION
Fixes issue with bad final commit in already-merged #138.  Please merge either #144 or this, they both do the trick.  Apologies for this :-|