### PR TITLE
Do not add a Main-Class attribute by default to a WAR

### DIFF
--- a/src/leiningen/ring/war/manifest.clj
+++ b/src/leiningen/ring/war/manifest.clj
@@ -41,9 +41,11 @@
          (merge
            (if (get project-manifest "Main-Class")
              default-manifest
-             (assoc default-manifest
-               "Main-Class"
-               (munge (str (:main project 'clojure.main))))))
+             (if-let [main (:main project)]
+               (assoc default-manifest
+                 "Main-Class"
+                 (munge (str main)))
+               default-manifest)))
          manifest-map-to-reordered-seq
          (manifest-entries project)
          (cons "Manifest-Version: 1.0\n")  ;; Manifest-Version line must be first


### PR DESCRIPTION
The Main-Class attribute of "clojure.main" was being the war and uberwar when :main was not specified in the project.clj. I have changed this so instead of defaulting to "clojure.main" the Main-Class attribute is excluded.

The default value caused a problem for me when attempting to deploy to Cloudfoundry which detected the .war file as an executable .jar and did not deploy it to a servlet container.
https://github.com/cloudfoundry/java-buildpack/blob/master/docs/container-tomcat.md