### PR TITLE
Forward a :bind option for starting a repl as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,16 @@ The following options affect the behavior of the web server started by
   If true, automatically refresh the browser when source or resource
   files are modified. Defaults to false.
 
-* `:nrepl` - 
-  A map of `:start?` and (optionally) `:port` keys. If `:start?` is true, 
-  open up an nREPL server on the given port. `:start?` defaults to false, 
-  `:port` defaults to an arbitrary free port.  __NOTE: This option is only
-  for development with the `lein ring server` task.  Setting this option
-  will not cause a generated uberjar/uberwar to run an nREPL server.  If
-  you would like to run an nREPL server in your production app, then see
-  the clojure.tools.nrepl.server project.__
+* `:nrepl` -
+  A map of `:start?` and (optionally) `:port` and `:bind` keys. If
+  `:start?` is true, open up an nREPL server on the given
+  port. `:start?` defaults to false, `:port` defaults to an arbitrary
+  free port, and `:bind` defaults to `"localhost"`.  __NOTE: This
+  option is only for development with the `lein ring server` task.
+  Setting this option will not cause a generated uberjar/uberwar to
+  run an nREPL server.  If you would like to run an nREPL server in
+  your production app, then see the clojure.tools.nrepl.server
+  project.__
 
 ## Executable jar files
 

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -52,10 +52,13 @@
      ~@(map #(if (symbol? %) (list 'var %) %) middleware)))
 
 (defn start-nrepl-expr [project]
-  (let [port (-> project :ring :nrepl (:port 0))
+  (let [nrepl-opts (-> project :ring :nrepl)
+        port (:port nrepl-opts 0)
+        bind (:bind nrepl-opts)
         handler (nrepl-handler (nrepl-middleware project))]
     `(let [{port# :port} (clojure.tools.nrepl.server/start-server
                           :port ~port
+                          :bind ~bind
                           :handler ~handler)]
        (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
          (-> port-file#


### PR DESCRIPTION
This is particularly useful when running inside a docker container, as
binding to localhost precludes exposing the port outside the container.