### PR TITLE
Issue #168 add-if-dependencies ignores transitive dependencies and th…

### DIFF
--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -219,7 +219,6 @@
 
 (defn add-servlet-dep [project]
   (-> project
-      (deps/add-if-missing '[ring/ring-servlet "1.2.1"])
       (deps/add-if-missing '[javax.servlet/servlet-api "2.5"])))
 
 (defn war


### PR DESCRIPTION
Pull request to fix issue #168 

add-if-dependencies ignores transitive dependencies and therefore may unexpectedly downgrade the project version of ring-servlet.
