### PR TITLE
Use ring 1.5.0 with both server & war tasks

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -30,7 +30,9 @@
   (update-project project deps/add-if-missing dep))
 
 (defn add-server-dep [project]
-  (add-dep project '[ring-server/ring-server "0.4.0"]))
+  (-> project
+      (add-dep '[ring "1.5.0"])
+      (add-dep '[ring-server/ring-server "0.4.0"])))
 
 (defn start-server-expr [project]
   `(ring.server.leiningen/serve '~(select-keys project [:ring])))

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -219,7 +219,7 @@
 
 (defn add-servlet-dep [project]
   (-> project
-      (deps/add-if-missing '[ring/ring-servlet "1.4.0"])
+      (deps/add-if-missing '[ring/ring-servlet "1.5.0"])
       (deps/add-if-missing '[javax.servlet/javax.servlet-api "3.1.0"])))
 
 (defn war


### PR DESCRIPTION
`[ring-server/ring-server "0.4.0"]` uses old version of ring, but we can force the new version here.