### PR TITLE
Bump to ring 1.5.1

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -31,7 +31,7 @@
 
 (defn add-server-dep [project]
   (-> project
-      (add-dep '[ring "1.5.0"])
+      (add-dep '[ring "1.5.1"])
       (add-dep '[ring-server/ring-server "0.4.0"])))
 
 (defn start-server-expr [project]

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -219,7 +219,7 @@
 
 (defn add-servlet-dep [project]
   (-> project
-      (deps/add-if-missing '[ring/ring-servlet "1.5.0"])
+      (deps/add-if-missing '[ring/ring-servlet "1.5.1"])
       (deps/add-if-missing '[javax.servlet/javax.servlet-api "3.1.0"])))
 
 (defn war


### PR DESCRIPTION
I need this update as I use `:pedantic? :abort` in my project, thus it prevents me to upgrade to ring 1.5.1!

And thanks for this great plugin btw :-)