### PR TITLE
Turning off :auto-refresh? for generated artifacts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The following options affect the behavior of the web server started by
 
 * `:auto-refresh?` -
   If true, automatically refresh the browser when source or resource
-  files are modified. Defaults to false.
+  files are modified. Defaults to false. Ignored (always false) for
+  generated artifacts.
 
 * `:nrepl` -
   A map of `:start?` and (optionally) `:port` and `:host` keys. If

--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -18,7 +18,8 @@
         options (-> (select-keys project [:ring])
                     (assoc-in [:ring :open-browser?] false)
                     (assoc-in [:ring :stacktraces?] false)
-                    (assoc-in [:ring :auto-reload?] false))]
+                    (assoc-in [:ring :auto-reload?] false)
+                    (assoc-in [:ring :auto-refresh?] false))]
     (compile-form project main-ns
       `(do (ns ~main-ns
              (:gen-class))


### PR DESCRIPTION
Following the same logic as `:stacktraces?` and `:auto-reload?`, I believe `:auto-refresh?` should also be turned off (ignored) for generated artifacts.
I was running an uberjar and saw the refresh middleware was still being used. 