### PR TITLE
Added ability to specify context-params in the project file.

### DIFF
--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -100,24 +100,45 @@
 
 (def default-servlet-version "2.5")
 
+(defn make-context-params
+  "Take this `params-map` and construct from it a sequence of
+  s-expression representations of context-param elements."
+  [params-map]
+  (if
+    (map? params-map)
+    (map
+      #(vector
+         :context-param
+         [:param-name (name %)]
+         [:param-value (params-map %)])
+      (keys params-map))))
+
+(defn make-web-sexpr
+  "Take this `project` and construct from it an s-expression
+  representation of the complete web.xml file"
+  [project]
+  (let [ring-options (:ring project)]
+    [:web-app
+     (get web-app-attrs
+          (get-in project [:ring :servlet-version] default-servlet-version)
+          {})
+     (make-context-params (:context-params ring-options))
+     [:listener
+      [:listener-class (listener-class project)]]
+     [:servlet
+      [:servlet-name  (servlet-name project)]
+      [:servlet-class (servlet-class project)]]
+     [:servlet-mapping
+      [:servlet-name (servlet-name project)]
+      [:url-pattern (url-pattern project)]]]))
+
 (defn make-web-xml [project]
   (let [ring-options (:ring project)]
     (if (contains? ring-options :web-xml)
       (slurp (:web-xml ring-options))
       (indent-str
         (sexp-as-element
-          [:web-app
-           (get web-app-attrs
-                (get-in project [:ring :servlet-version] default-servlet-version)
-                {})
-           [:listener
-            [:listener-class (listener-class project)]]
-           [:servlet
-            [:servlet-name  (servlet-name project)]
-            [:servlet-class (servlet-class project)]]
-           [:servlet-mapping
-            [:servlet-name (servlet-name project)]
-            [:url-pattern (url-pattern project)]]])))))
+          (make-web-sexpr project))))))
 
 (defn generate-handler [project handler-sym]
   (if (get-in project [:ring :servlet-path-info?] true)

--- a/test/leiningen/test/ring.clj
+++ b/test/leiningen/test/ring.clj
@@ -3,4 +3,4 @@
   (:use clojure.test))
 
 (deftest replace-me ;; FIXME: write
-  (is false "No tests have been written."))
+    (is false "No tests have been written."))

--- a/test/leiningen/test/war.clj
+++ b/test/leiningen/test/war.clj
@@ -1,0 +1,21 @@
+(ns leiningen.test.war
+  (:require [clojure.test :refer :all]
+            [leiningen.ring.war :refer :all]))
+
+(deftest test-generate-war
+  (testing "Generation of context params elements"
+    (is (empty? (make-context-params {}))
+        "If no context params are specified, none should be generated")
+    (is (empty? (make-context-params "froboz"))
+        "If the argument to make-context-params is not a map, no context params should be generated")
+    (is (= 1 (count (make-context-params {:foo "bar"})))
+        "If one context param is specified, one should be generated")
+    (is (= '([:context-param [:param-name "foo"][:param-value "bar"]])
+           (make-context-params {:foo "bar"})))
+    (is (= '([:context-param [:param-name "foo"][:param-value 123]])
+           (make-context-params {:foo 123})))
+    (is (= 2 (count (make-context-params {:foo "bar" :froboz "baz"})))
+        "If two context params are specified, two should be generated"))
+  (testing "Generation of war file"
+    (is (= "" (make-web-xml {:ring {:web-xml "/dev/null"}}))
+        "If a file path is specified as :web-xml, the content of that file should be returned")))


### PR DESCRIPTION
If you're building a project which may be delivered as an executable jar file, it's obvious that parameters can (and should) be supplied as environment variables. However, if you're delivering a project as a war file to be run within a servlet container, this isn't really possible as the war file may be deployed into an already running servlet engine whose environment variables one cannot readily alter.

While I agree that passing parameters as `context-params` in the `web.xml` file violates the principles of the [12 factor app](https://12factor.net/config), it is a well established mechanism for specifying parameters within the context of a web-app packaged as a war.

This patch provides a mechanism for specifying context parameters in the `:ring` map of the `project.clj` file. A key `:context-params` may be specified in this map; if it is specified, and its value is a map, then a `context-param` element will be generated in the generated `web.xml` file for each key/value pair in that map.