### PR TITLE
Update project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,5 +6,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/data.xml "0.0.8"]
-                 [leinjacker "0.4.2"]]
+                 [leinjacker "0.4.2"]
+                 [org.clojure/core.unify "0.5.7"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
This is to fix the issue of lein 2.9 + Clojure 1.10 + lein-ring crashing on `lein ring server` invocation.

Via @weavejester's recommendation

> If someone wants to submit a PR that mimics lein-jacker's dependency update function then that's fine by me.
But lein-ring should just need core.unify updated to 0.5.7 to get it working again.
Codox had the same issue.