### PR TITLE
Avoid jar-name collisions when building uberwar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,15 @@
-(defproject lein-ring "0.12.5"
+(defproject dpiliouras/lein-ring "0.12.7-SNAPSHOT"
   :description "Leiningen Ring plugin"
-  :url "https://github.com/weavejester/lein-ring"
+  :url "https://github.com/dpiliouras/lein-ring"
   :scm {:name "git"
-        :url "https://github.com/weavejester/lein-ring"}
+        :url "https://github.com/dpiliouras/lein-ring"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/core.unify "0.5.7"]
                  [org.clojure/data.xml "0.0.8"]
                  [leinjacker "0.4.2"
                   :exclusions [org.clojure/core.unify]]]
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                    :sign-releases false}]]
+
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,15 @@
-(defproject lein-ring "0.12.5"
+(defproject dpiliouras/lein-ring "0.12.5"
   :description "Leiningen Ring plugin"
-  :url "https://github.com/weavejester/lein-ring"
+  :url "https://github.com/dpiliouras/lein-ring"
   :scm {:name "git"
-        :url "https://github.com/weavejester/lein-ring"}
+        :url "https://github.com/dpiliouras/lein-ring"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/core.unify "0.5.7"]
                  [org.clojure/data.xml "0.0.8"]
                  [leinjacker "0.4.2"
                   :exclusions [org.clojure/core.unify]]]
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                    :sign-releases false}]]
+
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,12 @@
-(defproject dpiliouras/lein-ring "0.12.5"
+(defproject lein-ring "0.12.5"
   :description "Leiningen Ring plugin"
-  :url "https://github.com/dpiliouras/lein-ring"
+  :url "https://github.com/weavejester/lein-ring"
   :scm {:name "git"
-        :url "https://github.com/dpiliouras/lein-ring"}
+        :url "https://github.com/weavejester/lein-ring"}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/core.unify "0.5.7"]
                  [org.clojure/data.xml "0.0.8"]
                  [leinjacker "0.4.2"
                   :exclusions [org.clojure/core.unify]]]
-  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
-                                    :sign-releases false}]]
-
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dpiliouras/lein-ring "0.12.7-SNAPSHOT"
+(defproject dpiliouras/lein-ring "0.12.5"
   :description "Leiningen Ring plugin"
   :url "https://github.com/dpiliouras/lein-ring"
   :scm {:name "git"

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -64,7 +64,7 @@
                           :handler ~handler)]
        (doseq [port-file# ["target/repl-port" ".nrepl-port"]]
          (-> port-file#
-             java.io.File.
+             io/file
              (doto .deleteOnExit)
              (spit port#)))
        (println "Started nREPL server on port" port#))))
@@ -95,4 +95,4 @@
   ([project]
      (server-task project {}))
   ([project port]
-     (server-task project {:port (Integer. port)})))
+     (server-task project {:port (int port)})))

--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -94,5 +94,5 @@
   "Start a Ring server and open a browser."
   ([project]
      (server-task project {}))
-  ([project port]
-     (server-task project {:port (int port)})))
+  ([project ^String port]
+     (server-task project {:port (Integer. port)})))

--- a/src/leiningen/ring/server_headless.clj
+++ b/src/leiningen/ring/server_headless.clj
@@ -5,5 +5,5 @@
   "Start a Ring server without opening a browser."
   ([project]
      (server-task project {:open-browser? false}))
-  ([project port]
-     (server-task project {:port (int port), :open-browser? false})))
+  ([project ^String port]
+     (server-task project {:port (Integer. port), :open-browser? false})))

--- a/src/leiningen/ring/server_headless.clj
+++ b/src/leiningen/ring/server_headless.clj
@@ -6,4 +6,4 @@
   ([project]
      (server-task project {:open-browser? false}))
   ([project port]
-     (server-task project {:port (Integer. port), :open-browser? false})))
+     (server-task project {:port (int port), :open-browser? false})))

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -24,12 +24,12 @@
 (defn- contains-javax-servlet-class? [^JarFile jar-file]
   (some? (.getEntry jar-file "javax/servlet/Servlet.class")))
 
-(defn- pom-properties? [^JarEntry entry]
+(defn- pom-properties* [^JarEntry entry]
   (when (str/ends-with? (.getName entry) "pom.properties")
     entry))
 
 (defn- find-pom-properties [^JarFile jar-file]
-  (->> jar-file .entries enumeration-seq (some pom-properties?)))
+  (->> jar-file .entries enumeration-seq (some pom-properties*)))
 
 (defn- read-jar-pom-properties
   [^JarFile jar-file ^JarEntry pom-properties]

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -50,7 +50,7 @@
 
 (defn- war-path-for-jar [^File jar]
   (with-open [jar-file (JarFile. jar)]
-    ;; Servlet container will have it's own servlet-api impl
+    ;; Servlet container will have its own servlet-api implementation
     (when-not (contains-javax-servlet-class? jar-file)
       (let [name-from-pom (some->> (find-pom-properties jar-file)
                                    (jar-name-from-pom-properties jar-file))]

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -1,7 +1,10 @@
 (ns leiningen.ring.uberwar
   (:require [leiningen.ring.war :as war]
-            [clojure.java.io :as io])
-  (:import [java.util.jar JarFile JarEntry]))
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import [java.util.jar JarFile JarEntry]
+           (java.util Properties)
+           (java.net URL)))
 
 (defn default-uberwar-name [project]
   (or (get-in project [:ring :uberwar-name])
@@ -11,28 +14,45 @@
 (defn get-classpath [project]
   (if-let [get-cp (resolve 'leiningen.core.classpath/get-classpath)]
     (get-cp project)
-    (->> (:library-path project) io/file .listFiles (map str))))
-
-(defn contains-entry? [^java.io.File file ^String entry]
-  (with-open [jar-file (JarFile. file)]
-    (some (partial = entry)
-          (map #(.getName ^JarEntry %)
-               (enumeration-seq (.entries jar-file))))))
+    (->> (:library-path project) (io/file) .listFiles (map str))))
 
 (defn jar-dependencies [project]
   (for [pathname (get-classpath project)
-        :let [file (io/file pathname)
-              fname (.getName file)]
-        :when (and (.endsWith fname ".jar")
-                   ;; Servlet container will have it's own servlet-api impl
-                   (not (contains-entry? file "javax/servlet/Servlet.class")))]
-    file))
+        :when (str/ends-with? pathname ".jar")]
+    (io/file pathname)))
 
-(defn jar-entries [war project]
+(def ^:private javax-servlet?  #{"javax/servlet/Servlet.class"})
+(def ^:private pom-properties? #(str/ends-with? % "pom.properties"))
+
+(defn- war-path-for-jar
+  [^java.io.File jar]
+  (with-open [jar-file (JarFile. jar)]
+    (let [javax&pom (->> (.entries jar-file)
+                         enumeration-seq
+                         (map (fn [^JarEntry je] (.getName je)))
+                         (filter (some-fn javax-servlet? pom-properties?)))] ;; 2 elements maximum
+      ;; Servlet container will have it's own servlet-api impl
+      (when-not (some javax-servlet? javax&pom)
+        ;; we've confirmed that one of the two possible files is missing,
+        ;; so if we find one (via `first`), it will be the pom.properties
+        (let [pom-properties-full-path (some->> (first javax&pom)
+                                                (str "jar:file:" (.getAbsolutePath jar) "!/"))
+              {:strs [groupId artifactId version]} (when pom-properties-full-path
+                                                     (with-open [in (.openStream (URL. pom-properties-full-path))]
+                                                       (->> (doto (Properties.) (.load in))
+                                                            (into {}))))]
+          (->> (if (and groupId artifactId version)
+                 [groupId \- artifactId \- version ".jar"] ;; found pom.properties - reconstruct the jar name to avoid collisions (issue #216)
+                 [(.getName jar)])                         ;; fallback to using the original jar name (best-effort approach)
+               (apply str "WEB-INF/lib/")))))))
+
+(defn jar-entries
+  "Populates the 'WEB-INF/lib/' directory of the given <war> with this project's dependencies (jars).
+   If these contain a 'pom.properties' file, they will be copied into the war named as
+   $GROUP-$ARTIFACT-$VERSION.jar (see `war-path-for-jar`), otherwise using their original filename."
+  [war project]
   (doseq [jar-file (jar-dependencies project)]
-    (let [dir-path (.getParent jar-file)
-          war-path (war/in-war-path "WEB-INF/lib/" dir-path jar-file)]
-      (war/file-entry war project war-path jar-file))))
+    (war/file-entry war project (war-path-for-jar jar-file) jar-file)))
 
 (defn uberwar
   "Create a $PROJECT-$VERSION.war with dependencies."
@@ -43,3 +63,12 @@
        project war-name
        :profiles-to-merge [:uberjar]
        :additional-writes jar-entries)))
+
+(comment
+  ;; will only work under *NIX
+  (let [clojure-jar (-> (System/getProperty "user.home")
+                        (io/file ".m2/repository/org/clojure/clojure/1.10.1/clojure-1.10.1.jar"))]
+    (= "WEB-INF/lib/org.clojure-clojure-1.10.1.jar" ;; <group-id>-<artifact-id>-<version>.jar
+       (war-path-for-jar clojure-jar))
+    )
+  )

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -52,7 +52,8 @@
    $GROUP-$ARTIFACT-$VERSION.jar (see `war-path-for-jar`), otherwise using their original filename."
   [war project]
   (doseq [jar-file (jar-dependencies project)]
-    (war/file-entry war project (war-path-for-jar jar-file) jar-file)))
+    (when-let [war-path (war-path-for-jar jar-file)]
+      (war/file-entry war project war-path jar-file))))
 
 (defn uberwar
   "Create a $PROJECT-$VERSION.war with dependencies."

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -32,14 +32,14 @@
     (->> (doto (Properties.) (.load in))
          (into {}))))
 
-(defn- from-pom-properties
-  "Returns a jar name which includes the groupId, artifactId, & version,
-   as read by the pom.properties file inside the jar file found at <jar-path>."
+(defn- jar-name-from-pom-properties
   [jar-path pom-properties-jar-path]
-  (let [pom-properties-full-path (str "jar:file:" jar-path "!/" pom-properties-jar-path)
-        {:strs [groupId artifactId version]} (read-jar-pom-properties pom-properties-full-path)]
+  (let [pom-properties-full-path (str "jar:file:"
+                                      jar-path "!/"
+                                      pom-properties-jar-path)
+        {:strs [groupId artifactId version]} (read-jar-pom-properties
+                                               pom-properties-full-path)]
     (when (and groupId artifactId version)
-      ;; found pom.properties - reconstruct the jar name to avoid collisions (issue #216)
       (str groupId \- artifactId \- version ".jar"))))
 
 (defn- war-path-for-jar [^File jar]
@@ -50,18 +50,13 @@
                          (filter (some-fn javax-servlet? pom-properties?)))] ;; 2 elements maximum
       ;; Servlet container will have it's own servlet-api impl
       (when-not (some javax-servlet? javax&pom)
-        ;; we've confirmed that one of the two possible files is missing,
-        ;; so if we find one (via `first`), it will be the pom.properties
         (str "WEB-INF/lib/"
              (or (some->> (first javax&pom)
-                          (from-pom-properties (.getAbsolutePath jar)))
+                          (jar-name-from-pom-properties (.getAbsolutePath jar)))
                  ;; fallback to using the original jar name (best-effort approach)
                  (.getName jar)))))))
 
-(defn- jar-entries
-  "Populates the 'WEB-INF/lib/' directory of the given <war> with this project's dependencies (jars).
-   If these contain a 'pom.properties' file, they will be copied into the war named as
-   $GROUP-$ARTIFACT-$VERSION.jar (see `war-path-for-jar`), otherwise using their original filename."
+(defn- populate-war-with-dependent-jars
   [war project]
   (doseq [jar-file (jar-dependencies project)]
     (when-let [war-path (war-path-for-jar jar-file)]
@@ -75,13 +70,5 @@
      (war/war
        project war-name
        :profiles-to-merge [:uberjar]
-       :additional-writes jar-entries)))
+       :additional-writes populate-war-with-dependent-jars)))
 
-(comment
-  ;; will only work under *NIX
-  (let [clojure-jar (-> (System/getProperty "user.home")
-                        (io/file ".m2/repository/org/clojure/clojure/1.10.1/clojure-1.10.1.jar"))]
-    (= "WEB-INF/lib/org.clojure-clojure-1.10.1.jar" ;; <group-id>-<artifact-id>-<version>.jar
-       (war-path-for-jar clojure-jar))
-    )
-  )

--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -25,11 +25,6 @@
   (some? (.getEntry jar-file "javax/servlet/Servlet.class")))
 
 (defn- pom-properties? [^JarEntry entry]
-  (when (-> (.getName entry)
-            (str/ends-with? "pom.properties"))
-    entry))
-
-(defn- pom-properties? [^JarEntry entry]
   (when (str/ends-with? (.getName entry) "pom.properties")
     entry))
 

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -31,7 +31,8 @@
           "  :ring {:handler your.app/handler}"))
     (lein-core/exit 1)))
 
-(defn source-file [project namespace]
+(defn source-file
+  ^java.io.File [project namespace]
   (io/file (:compile-path project)
            (-> (str namespace)
                (str/replace "-" "_")

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -5,7 +5,7 @@
             [leiningen.deps]
             [leiningen.core.main :as lein-core]
             [leinjacker.utils :as lju])
-  (:import (java.io File)))
+  (:import [java.io File]))
 
 (defn find-namespaces [var-syms]
   (->> (remove nil? var-syms)
@@ -32,8 +32,7 @@
           "  :ring {:handler your.app/handler}"))
     (lein-core/exit 1)))
 
-(defn source-file
-  ^File [project namespace]
+(defn source-file ^File [project namespace]
   (io/file (:compile-path project)
            (-> (str namespace)
                (str/replace "-" "_")

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -4,7 +4,8 @@
             [clojure.java.io :as io]
             [leiningen.deps]
             [leiningen.core.main :as lein-core]
-            [leinjacker.utils :as lju]))
+            [leinjacker.utils :as lju])
+  (:import (java.io File)))
 
 (defn find-namespaces [var-syms]
   (->> (remove nil? var-syms)
@@ -32,11 +33,11 @@
     (lein-core/exit 1)))
 
 (defn source-file
-  ^java.io.File [project namespace]
+  ^File [project namespace]
   (io/file (:compile-path project)
            (-> (str namespace)
                (str/replace "-" "_")
-               (str/replace "." java.io.File/separator)
+               (str/replace "." File/separator)
                (str ".clj"))))
 
 (defn compile-form

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -23,7 +23,7 @@
     (.mkdirs (io/file target-dir))
     (str target-dir "/" war-name)))
 
-(defn skip-file? [project war-path ^java.io.File file]
+(defn skip-file? [project war-path ^File file]
   (or (re-find #"^\.?#" (.getName file))
       (re-find #"~$" (.getName file))
       (some #(re-find % war-path)
@@ -169,8 +169,7 @@
                       `(~(generate-resolve destroy-sym)))))))
       :print-meta true)))
 
-(defn create-war
-  ^JarOutputStream [project ^String file-path]
+(defn create-war ^JarOutputStream [project ^String file-path]
   (-> (FileOutputStream. file-path)
       (BufferedOutputStream.)
       (JarOutputStream. (make-manifest project))))
@@ -187,13 +186,13 @@
 (defn str-entry [war war-path content]
   (write-entry war war-path (to-byte-stream content)))
 
-(defn in-war-path [war-path root ^java.io.File file]
+(defn in-war-path [war-path root ^File file]
   (str war-path
        (-> (.toURI (io/file root))
            (.relativize (.toURI file))
            (.getPath))))
 
-(defn file-entry [war project ^String war-path ^java.io.File file]
+(defn file-entry [war project ^String war-path ^File file]
   (when (and (.exists file)
              (.isFile file)
              (not (skip-file? project war-path file)))

--- a/src/leiningen/ring/war/manifest.clj
+++ b/src/leiningen/ring/war/manifest.clj
@@ -35,8 +35,7 @@
         (not (coll? (second e1)))))
     (seq mf)))
 
-(defn make-manifest
-  ^Manifest [project]
+(defn make-manifest ^Manifest [project]
   (let [project-manifest (into {} (:manifest project))]
     (->> project-manifest
          (merge

--- a/src/leiningen/ring/war/manifest.clj
+++ b/src/leiningen/ring/war/manifest.clj
@@ -35,7 +35,8 @@
         (not (coll? (second e1)))))
     (seq mf)))
 
-(defn make-manifest [project]
+(defn make-manifest
+  ^Manifest [project]
   (let [project-manifest (into {} (:manifest project))]
     (->> project-manifest
          (merge


### PR DESCRIPTION
This mainly addresses #216, but also removes reflection. 