### PR TITLE
Update nrepl to 1.0.0

### DIFF
--- a/src/leiningen/ring/server.clj
+++ b/src/leiningen/ring/server.clj
@@ -42,7 +42,7 @@
 
 (defn add-optional-nrepl-dep [project]
   (if (nrepl? project)
-    (add-dep project '[nrepl "0.6.0"])
+    (add-dep project '[nrepl "1.0.0"])
     project))
 
 (defn nrepl-middleware [project]


### PR DESCRIPTION
nrepl release 1.0.0 is available since a while: https://github.com/nrepl/nrepl/releases/tag/1.0.0.