### PR TITLE
Update ring-jakarta-servlet dependency version and add web.xml for versions 6.0 and 6.1

### DIFF
--- a/src/leiningen/ring/uberwar.clj
+++ b/src/leiningen/ring/uberwar.clj
@@ -21,8 +21,8 @@
         :when (str/ends-with? pathname ".jar")]
     (io/file pathname)))
 
-(defn- contains-javax-servlet-class? [^JarFile jar-file]
-  (some? (.getEntry jar-file "javax/servlet/Servlet.class")))
+(defn- contains-jakarta-servlet-class? [^JarFile jar-file]
+  (some? (.getEntry jar-file "jakarta/servlet/Servlet.class")))
 
 (defn- pom-properties* [^JarEntry entry]
   (when (str/ends-with? (.getName entry) "pom.properties")
@@ -46,7 +46,7 @@
 (defn- war-path-for-jar [^File jar]
   (with-open [jar-file (JarFile. jar)]
     ;; Servlet container will have its own servlet-api implementation
-    (when-not (contains-javax-servlet-class? jar-file)
+    (when-not (contains-jakarta-servlet-class? jar-file)
       (let [name-from-pom (some->> (find-pom-properties jar-file)
                                    (jar-name-from-pom-properties jar-file))]
         (->> (or name-from-pom (.getName jar))

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -88,4 +88,4 @@
     (merge-fn project profiles)
     project))
 
-(def ring-version "1.6.1")
+(def ring-version "1.13.0")

--- a/src/leiningen/ring/util.clj
+++ b/src/leiningen/ring/util.clj
@@ -88,4 +88,4 @@
     (merge-fn project profiles)
     project))
 
-(def ring-version "1.13.0")
+(def ring-version "1.14.2")

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -123,7 +123,7 @@
     `(let [handler# ~(generate-resolve handler-sym)]
        (fn [request#]
          (let [context# (.getContextPath
-                          ^javax.servlet.http.HttpServletRequest
+                          ^jakarta.servlet.http.HttpServletRequest
                           (:servlet-request request#))]
            (handler#
             (assoc request#
@@ -135,7 +135,7 @@
   (let [servlet-ns  (symbol (servlet-ns project))]
     (compile-form project servlet-ns
       `(do (ns ~servlet-ns
-             (:gen-class :extends javax.servlet.http.HttpServlet))
+             (:gen-class :extends jakarta.servlet.http.HttpServlet))
            (def ~'service-method)
            (defn ~'-service [servlet# request# response#]
              (~'service-method servlet# request# response#)))
@@ -151,7 +151,7 @@
     (assert-vars-exist project init-sym destroy-sym handler-sym)
     (compile-form project project-ns
       `(do (ns ~project-ns
-             (:gen-class :implements [javax.servlet.ServletContextListener]))
+             (:gen-class :implements [jakarta.servlet.ServletContextListener]))
            ~(let [servlet-context-event (gensym)]
               `(do
                  (defn ~'-contextInitialized [this# ~servlet-context-event]
@@ -159,7 +159,7 @@
                       `(~(generate-resolve init-sym)))
                    (let [handler# ~(generate-handler project handler-sym)
                          make-service-method# ~(generate-resolve
-                                                 'ring.util.servlet/make-service-method)
+                                                 'ring.util.jakarta.servlet/make-service-method)
                          method# (make-service-method# handler# ~@(when async? [{:async? true}]))]
                      (alter-var-root
                        ~(generate-resolve (symbol servlet-ns "service-method"))
@@ -233,8 +233,8 @@
 
 (defn add-servlet-dep [project]
   (-> project
-      (deps/add-if-missing ['ring/ring-servlet ring-version])
-      (deps/add-if-missing '[javax.servlet/javax.servlet-api "3.1.0"])))
+      (deps/add-if-missing ['org.ring-clojure/ring-jakarta-servlet ring-version])
+      (deps/add-if-missing '[jakarta.servlet/jakarta.servlet-api "6.1.0"])))
 
 (defn war
   "Create a $PROJECT-$VERSION.war file."

--- a/src/leiningen/ring/war.clj
+++ b/src/leiningen/ring/war.clj
@@ -95,9 +95,21 @@
           :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
           :xsi:schemaLocation (str "http://java.sun.com/xml/ns/javaee "
                                    "http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd")
-          :version "3.0"}})
+          :version "3.0"}
 
-(def default-servlet-version "2.5")
+   "6.0" {:xmlns     "https://jakarta.ee/xml/ns/jakartaee"
+          :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+          :xsi:schemaLocation (str "https://jakarta.ee/xml/ns/jakartaee "
+                                   "https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd")
+          :version "6.0"}
+
+   "6.1" {:xmlns     "https://jakarta.ee/xml/ns/jakartaee"
+          :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+          :xsi:schemaLocation (str "https://jakarta.ee/xml/ns/jakartaee "
+                                   "https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd")
+          :version "6.1"}})
+
+(def default-servlet-version "6.0")
 
 (defn make-web-xml [project]
   (let [ring-options (:ring project)]


### PR DESCRIPTION
This pull request also incorporates the updates in pull request #224 from @madoxas.

With the shift from javax.* to jakarta.* package names, the minimum supported Tomcat version is 10.1 at the moment and it uses servlet version 6.0. I also added the web.xml servlet definition for Tomcat version 11.